### PR TITLE
reduce db calls for typical cases & increase timestamp resolution

### DIFF
--- a/dbtest/go.mod
+++ b/dbtest/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/dynata/go-dbmutex v0.0.0-20201101151841-91142163ea71
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/lib/pq v1.8.0
+	github.com/luna-duclos/instrumentedsql v1.1.4-0.20201103091713-40d03108b6f4
 	github.com/ory/dockertest/v3 v3.6.2
 )

--- a/dbtest/go.sum
+++ b/dbtest/go.sum
@@ -28,6 +28,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/luna-duclos/instrumentedsql v1.1.4-0.20201103091713-40d03108b6f4 h1:ly0ZQvqtRkgKeTURKghyPnb5+/mTcc1taKkiILifYWw=
+github.com/luna-duclos/instrumentedsql v1.1.4-0.20201103091713-40d03108b6f4/go.mod h1:9J1njvFds+zN7y85EDhN9XNQLANWwZt2ULeIC8yMNYs=
 github.com/moby/term v0.0.0-20200915141129-7f0af18e79f2 h1:SPoLlS9qUUnXcIY4pvA4CTwYjk0Is5f4UPEkeESr53k=
 github.com/moby/term v0.0.0-20200915141129-7f0af18e79f2/go.mod h1:TjQg8pa4iejrUrjiz0MCtMV38jdMNW4doKSiBrEvCQQ=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=

--- a/map_test.go
+++ b/map_test.go
@@ -66,8 +66,16 @@ func (t *testMutexAllocator) mutexAllocator(context.Context, *sql.DB, ...MutexOp
 
 func TestMutexMap_SimpleLockUnlock(t *testing.T) {
 	ma := &testMutexAllocator{}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
-	_, err := mm.Lock(context.Background(), "X")
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = mm.Lock(context.Background(), "X")
 	if err != nil {
 		t.Error(err)
 		return
@@ -88,7 +96,15 @@ func TestMutexMap_SimpleLockUnlock(t *testing.T) {
 func TestMutexMap_Concurrent(t *testing.T) {
 	concurrency := 10000
 	ma := &testMutexAllocator{}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	acc := int32(0)
 	wg := sync.WaitGroup{}
@@ -120,7 +136,15 @@ func TestMutexMap_Concurrent(t *testing.T) {
 
 func TestMutexMap_MapStaysSmall(t *testing.T) {
 	ma := &testMutexAllocator{}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	maxI := 100
 	maxJ := 100
 	for i := 0; i < maxI; i++ {
@@ -149,7 +173,15 @@ func TestMutexMap_MapStaysSmall(t *testing.T) {
 
 func TestMutexMap_MapStaysSmallWithConcurrency(t *testing.T) {
 	ma := &testMutexAllocator{}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	maxI := 100
 	maxJ := 100
 	wg := sync.WaitGroup{}
@@ -196,7 +228,16 @@ func TestMutexMap_MaxLocalWaiters(t *testing.T) {
 	maxWaiters := 10
 	for waiters := minWaiters; waiters <= maxWaiters; waiters++ {
 		ma := &testMutexAllocator{}
-		mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator), WithMaxLocalWaiters(int32(waiters)))
+		options := []MutexMapOption{
+			withMutexAllocator(ma.mutexAllocator),
+			WithMaxLocalWaiters(int32(waiters)),
+			WithDelayResolveDriver(true),
+			WithDelayCreateMissingTable(true),
+		}
+		mm, err := NewMutexMap(context.Background(), nil, options...)
+		if err != nil {
+			t.Fatal(err)
+		}
 		maxI := 100
 		wg := sync.WaitGroup{}
 		lockName := "testLock"
@@ -245,7 +286,15 @@ func TestMutexMap_MaxLocalWaiters(t *testing.T) {
 
 func TestMutexMap_LockTimeout(t *testing.T) {
 	ma := &testMutexAllocator{}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	lockName := "testLock"
 	lockIsHeld := sync.WaitGroup{}
 	lockIsHeld.Add(1)
@@ -286,7 +335,7 @@ func TestMutexMap_LockTimeout(t *testing.T) {
 	bothDone.Wait()
 
 	// now should be able to acquire after a waiting lock timeout
-	_, err := mm.Lock(context.Background(), lockName)
+	_, err = mm.Lock(context.Background(), lockName)
 	if err != nil {
 		t.Error(err)
 		return
@@ -302,7 +351,15 @@ func TestMutexMap_AllocationFailure(t *testing.T) {
 	ma := &testMutexAllocator{
 		failOnAllocationCallNum: 1,
 	}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	lockName := "testLock"
 	lockCtx, err := mm.Lock(context.Background(), lockName)
 	if err != errFailedAllocation {
@@ -328,7 +385,15 @@ func TestMutexMap_LockFailure(t *testing.T) {
 	ma := &testMutexAllocator{
 		failOnLockCallNum: 2,
 	}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	lockName := "testLock"
 
 	lockIsHeld := sync.WaitGroup{}
@@ -387,7 +452,15 @@ func TestMutexMap_UnlockFailure(t *testing.T) {
 	ma := &testMutexAllocator{
 		failOnUnlockCallNum: 2,
 	}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	lockName := "testLock"
 
 	lockIsHeld := sync.WaitGroup{}
@@ -448,9 +521,17 @@ func TestMutexMap_UnlockFailure(t *testing.T) {
 
 func TestMutexMap_UnlockNotLocked(t *testing.T) {
 	ma := &testMutexAllocator{}
-	mm := NewMutexMap(nil, withMutexAllocator(ma.mutexAllocator))
+	options := []MutexMapOption{
+		withMutexAllocator(ma.mutexAllocator),
+		WithDelayResolveDriver(true),
+		WithDelayCreateMissingTable(true),
+	}
+	mm, err := NewMutexMap(context.Background(), nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	lockName := "testLock"
-	err := mm.Unlock(context.Background(), lockName)
+	err = mm.Unlock(context.Background(), lockName)
 	var e dbmerr.NotLockedError
 	if !errors.As(err, &e) {
 		t.Errorf("expected error to be not locked but was %v", err)

--- a/option.go
+++ b/option.go
@@ -18,6 +18,7 @@ type mutexOptions struct {
 	refreshErrNotifier ErrorNotifier
 	failFast           bool
 	pollInterval       time.Duration
+	delayAddMutexRow   bool
 }
 
 // MutexOption is used to customize Mutex behaviour.
@@ -31,6 +32,14 @@ func WithErrorNotifier(f ErrorNotifier) MutexOption {
 		o.lockErrNotifier = f
 		o.unlockErrNotifier = f
 		o.refreshErrNotifier = f
+	}
+}
+
+// WithDelayAddMutexRow can be used to change the default (false) case for delaying the insertion of a row
+// into the mutex table.
+func WithDelayAddMutexRow(delay bool) MutexOption {
+	return func(o *mutexOptions) {
+		o.delayAddMutexRow = delay
 	}
 }
 


### PR DESCRIPTION
- MutexMap now determines the db driver and creates the mutex table
once instead of one check per Mutex created.
- Lock will now attempt to insert a locked row if one is missing vs.
always inserting a new unlocked row at Mutex creation time.
- mysql timestamps now use millisecond vs second resolution.